### PR TITLE
Refactor to separate ISBN modules by type

### DIFF
--- a/lib/isbn_10.ex
+++ b/lib/isbn_10.ex
@@ -1,0 +1,60 @@
+defmodule ISBN.ISBN10 do
+  @moduledoc """
+  Validation and tools for ISBN-10
+  """
+
+  import ISBN, only: [normalize: 1, chars: 1]
+
+  @doc """
+  Validates ISBN-10
+
+  Examples:
+      iex> ISBN.ISBN10.valid?("0-8219-1069-8")
+      true
+  """
+  def valid?(code) when is_binary(code), do: code |> normalize |> chars |> valid?
+  def valid?(chars) when is_list(chars) and length(chars) == 10 do
+    checkdigit(chars) == Enum.at(chars, 9)
+  end
+  def valid?(_), do: false
+
+  @doc """
+  ISBN-10 codes can be converted to ISBN-13 by prepending "978" and re-calculating the checkdigit.
+
+  Example:
+      iex> ISBN.ISBN10.to_isbn13("1937785580")
+      "9781937785581"
+  """
+  def to_isbn13(str) do
+    isbn = normalize(str)
+    case valid?(isbn) do
+      false -> {:error, :invalid}
+      _ -> append_isbn_13_checkdigit("978" <> String.slice(isbn, 0..8))
+    end
+  end
+
+  @doc """
+  Calculate checksum. Return type is string since when the digit is "10", "X" is used in its place
+
+  Examples:
+      iex> ISBN.ISBN10.checkdigit(["0", "8", "0", "4", "4", "2", "9", "5", "7"])
+      "X"
+  """
+  def checkdigit(chars) do
+    chars
+    |> Enum.take(9)
+    |> Enum.map(&String.to_integer/1)
+    |> Enum.zip(10..2)
+    |> Enum.map(fn {a, b} -> a * b end)
+    |> Enum.sum
+    |> rem(11)
+    |> (fn x -> rem(11 - x, 11) end).()
+    |> Integer.to_string
+    |> String.replace("10", "X")
+  end
+
+  defp append_isbn_13_checkdigit(stub) do
+    new_checkdigit = stub |> chars |> ISBN.ISBN13.checkdigit
+    stub <> new_checkdigit
+  end
+end

--- a/lib/isbn_13.ex
+++ b/lib/isbn_13.ex
@@ -1,0 +1,35 @@
+defmodule ISBN.ISBN13 do
+  @moduledoc """
+  Validation for ISBN-13
+  """
+
+  import ISBN, only: [normalize: 1, chars: 1]
+
+  @doc """
+  Validate the chechksum on an ISBN-10 or ISBN-13 string
+
+  Examples:
+      iex> ISBN.ISBN13.valid?("978-1-93778-558-1")
+      true
+
+      iex> ISBN.ISBN13.valid?("978-1-93778-558-0")
+      false
+  """
+  def valid?(code) when is_binary(code), do: code |> normalize |> chars |> valid?
+  def valid?(chars) when is_list(chars) and length(chars) == 13 do
+    checkdigit(chars) == Enum.at(chars, 12)
+  end
+  def valid?(_), do: :what
+
+  def checkdigit(chars) do
+    chars
+    |> Enum.take(12)
+    |> Enum.map(&String.to_integer/1)
+    |> Enum.zip(Stream.cycle([1, 3]))
+    |> Enum.map(fn {a, b} -> a * b end)
+    |> Enum.sum
+    |> rem(10)
+    |> (fn x -> 10 - x end).()
+    |> Integer.to_string
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -7,9 +7,9 @@ defmodule ISBN.Mixfile do
      elixir: "~> 1.3",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps,
+     deps: deps(),
      description: "A package to check valid ISBNs",
-     package: package,
+     package: package(),
     ]
   end
 

--- a/test/isbn_10_test.exs
+++ b/test/isbn_10_test.exs
@@ -1,0 +1,4 @@
+defmodule ISBN.ISBN10Test do
+  use ExUnit.Case, async: true
+  doctest ISBN.ISBN10
+end

--- a/test/isbn_13_test.exs
+++ b/test/isbn_13_test.exs
@@ -1,0 +1,4 @@
+defmodule ISBN.ISBN13Test do
+  use ExUnit.Case, async: true
+  doctest ISBN.ISBN13
+end

--- a/test/isbn_test.exs
+++ b/test/isbn_test.exs
@@ -27,12 +27,12 @@ defmodule ISBNTest do
     assert ISBN.valid?("978-0-306-40615-7")
   end
 
-  test "convert_10_to_13/1 converts valid isbns" do
-    assert "9781617292019" == ISBN.convert_10_to_13("161729201X")
-    assert "9781937785581" == ISBN.convert_10_to_13("1937785580")
+  test "to_isbn13/1 converts valid isbns" do
+    assert "9781617292019" == ISBN.to_isbn13("161729201X")
+    assert "9781937785581" == ISBN.to_isbn13("1937785580")
   end
 
-  test "convert_10_to_13/1 fails for invalid isbn" do
-    assert {:error, :invalid_isbn} == ISBN.convert_10_to_13("123")
+  test "to_isbn13/1 fails for invalid isbn" do
+    assert {:error, :invalid_isbn} == ISBN.to_isbn13("123")
   end
 end


### PR DESCRIPTION
Hello!

First off, I like the ISBN library you created. Works great and the validation pipeline is really cool.

Since ISBN-10 and -13 are effectively different entities, I thought it would help readability and maintainability to have them in separate modules. This PR creates a `ISBN10` and `ISBN13` module and retains the `ISBN` module as an entrypoint that bridges both.